### PR TITLE
Add default connection values to UI

### DIFF
--- a/web-ui/flask_server.py
+++ b/web-ui/flask_server.py
@@ -28,9 +28,9 @@ app = Flask(__name__)
 @app.route("/")
 def main():
     # get url parameters for HTML template
-    name_arg = request.args.get('name', '')
-    addr_arg = request.args.get('addr', '')
-    port_arg = request.args.get('port', '')
+    name_arg = request.args.get('name', 'mnist-serve')
+    addr_arg = request.args.get('addr', 'mnist-serve')
+    port_arg = request.args.get('port', '9000')
     args = {"name": name_arg, "addr": addr_arg, "port": port_arg}
     print(args)
 


### PR DESCRIPTION
Resolves "Could not Connect to server" error message when opening the web UI by providing defaults